### PR TITLE
docs: improve README, fix links and capitalization.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Get the entire DialogWeaver platform running on your local machine in just a few
 
 ### 1. Clone the Repository
 ```bash
-git clone https://github.com/your-username/dialogweaver.git
+git clone https://github.com/Hiteshydv001/DialogWeaver.git
 cd DialogWeaver
 ```
 
@@ -101,4 +101,5 @@ Please read our **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started with the d
 ## License
 
 This project is licensed under the MIT License - see the **[LICENSE](LICENSE)** file for details.
+
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/OpenVoiceX/DialogWeaver/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <a href="https://github.com/OpenVoiceX/DialogWeaver/issues"><img src="https://img.shields.io/github/issues/your-username/dialogweaver" alt="GitHub issues"></a>
   <a href="https://github.com/OpenVoiceX/DialogWeaver/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-Welcome-brightgreen.svg" alt="PRs Welcome"></a>
-  <a href="#"><img src="https://img.shields.io/static/v1?label=Discord&message=Join%20Chat&color=7289DA&logo=discord" alt="Join the community on Discord"></a>
+ 
 </p>
 
 ---
@@ -101,6 +101,7 @@ Please read our **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started with the d
 ## License
 
 This project is licensed under the MIT License - see the **[LICENSE](LICENSE)** file for details.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/your-username/dialogweaver/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="https://github.com/Hiteshydv001/DialogWeaver/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <a href="https://github.com/Hiteshydv001/DialogWeaver/issues"><img src="https://img.shields.io/github/issues/your-username/dialogweaver" alt="GitHub issues"></a>
   <a href="https://github.com/Hiteshydv001/DialogWeaver/blob/main/docs/Contribution.md"><img src="https://img.shields.io/badge/PRs-Welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a href="#"><img src="https://img.shields.io/static/v1?label=Discord&message=Join%20Chat&color=7289DA&logo=discord" alt="Join the community on Discord"></a>
@@ -58,7 +58,7 @@ Get the entire DialogWeaver platform running on your local machine in just a few
 ### 1. Clone the Repository
 ```bash
 git clone https://github.com/your-username/dialogweaver.git
-cd dialogweaver
+cd DialogWeaver
 ```
 
 ### 2. Configure Your Environment
@@ -101,3 +101,4 @@ Please read our **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started with the d
 ## License
 
 This project is licensed under the MIT License - see the **[LICENSE](LICENSE)** file for details.
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/OpenVoiceX/DialogWeaver/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://github.com/OpenVoiceX/DialogWeaver/issues"><img src="https://img.shields.io/github/issues/your-username/dialogweaver" alt="GitHub issues"></a>
+  <a href="https://github.com/OpenVoiceX/DialogWeaver/issues"><img src="https://img.shields.io/github/issues/OpenVoiceX/DialogWeaver" alt="GitHub issues"></a>
   <a href="https://github.com/OpenVoiceX/DialogWeaver/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-Welcome-brightgreen.svg" alt="PRs Welcome"></a>
  
 </p>
@@ -101,6 +101,7 @@ Please read our **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started with the d
 ## License
 
 This project is licensed under the MIT License - see the **[LICENSE](LICENSE)** file for details.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Hiteshydv001/DialogWeaver/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://github.com/Hiteshydv001/DialogWeaver/issues"><img src="https://img.shields.io/github/issues/your-username/dialogweaver" alt="GitHub issues"></a>
-  <a href="https://github.com/Hiteshydv001/DialogWeaver/blob/main/docs/Contribution.md"><img src="https://img.shields.io/badge/PRs-Welcome-brightgreen.svg" alt="PRs Welcome"></a>
+  <a href="https://github.com/OpenVoiceX/DialogWeaver/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="https://github.com/OpenVoiceX/DialogWeaver/issues"><img src="https://img.shields.io/github/issues/your-username/dialogweaver" alt="GitHub issues"></a>
+  <a href="https://github.com/OpenVoiceX/DialogWeaver/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-Welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a href="#"><img src="https://img.shields.io/static/v1?label=Discord&message=Join%20Chat&color=7289DA&logo=discord" alt="Join the community on Discord"></a>
 </p>
 
@@ -42,7 +42,7 @@ DialogWeaver is built as a modern, service-oriented monorepo. This design provid
 | **`database`**| Persistent relational data storage.                                         | `PostgreSQL`                                       |
 | **`cache`**   | In-memory data store for caching and session management.                    | `Redis`                                            |
 
-![DialogWeaver Architecture Diagram](https://github.com/Hiteshydv001/DialogWeaver/blob/main/docs/Architecture.png)
+![DialogWeaver Architecture Diagram](https://github.com/OpenVoiceX/DialogWeaver/blob/main/docs/Architecture.png)
 
 
 ---
@@ -101,6 +101,7 @@ Please read our **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started with the d
 ## License
 
 This project is licensed under the MIT License - see the **[LICENSE](LICENSE)** file for details.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Get the entire DialogWeaver platform running on your local machine in just a few
 
 ### 1. Clone the Repository
 ```bash
-git clone https://github.com/Hiteshydv001/DialogWeaver.git
+git clone https://github.com/OpenVoiceX/DialogWeaver.git
 cd DialogWeaver
 ```
 
@@ -101,5 +101,6 @@ Please read our **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started with the d
 ## License
 
 This project is licensed under the MIT License - see the **[LICENSE](LICENSE)** file for details.
+
 
 


### PR DESCRIPTION
This PR fixes several small issues in the README.md file, including incorrect repository links, and a typo in a code block:

Corrected Typo & Capitalization: Fixed inconsistent capitalization of "no-code UI playground" to match the "No-Code Agent Builder" heading.

Updated Links: Corrected the URLs for the license and issues badges to point to the main repository, Hiteshydv001/DialogWeaver, instead of your-username/dialogweaver.

Resolved Code Block Typo: Changed the git clone command in the "Quick Start" section to use the correct repository name, DialogWeaver, instead of dialogweaver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README badges and links to the repository’s canonical locations.
  * Replaced architecture diagram link with the canonical repository version.
  * Removed Discord badge/section from header.
  * Updated Quick Start clone URL and repository directory name.
  * Rebranded and expanded README content (Key Features, Architecture, deployment instructions).
  * Minor formatting cleanup (trailing newlines and spacing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->